### PR TITLE
Fix tryCatch structure and null handling in app_server

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -17,23 +17,24 @@ app_server <- function(input, output, session) {
 		if (is.null(df)) {
 			"File non ancora caricato"
 		} else {
-			tryCatch({
-				if(gruppo() == "vuoto") {
-					return(paste0("File vuoto: ", colnames(df)[1]))
-				}else{
-				paste("File importato correttamente. Gruppo specie:", gruppo())
-				}, error = function(e) {
-				paste("Errore nel file:", e$message)
-			
-			})
-		}
-	})
-	
-	
-	# ottieni il numero di righe dei dati importati
-	
-	output$n_animali <- renderText({
-		df <- animali()
-		paste("Numero di animali importati:", nrow(df))
-	})
+                        tryCatch({
+                                if (gruppo() == "vuoto") {
+                                        return(paste0("File vuoto: ", colnames(df)[1]))
+                                } else {
+                                        paste("File importato correttamente. Gruppo specie:", gruppo())
+                                }
+                        }, error = function(e) {
+                                paste("Errore nel file:", e$message)
+                        })
+                }
+        })
+
+
+        # ottieni il numero di righe dei dati importati
+
+        output$n_animali <- renderText({
+                df <- animali()
+                req(df)
+                paste("Numero di animali importati:", nrow(df))
+        })
 }


### PR DESCRIPTION
## Summary
- Correct the `tryCatch` structure in `output$tipo_file` to fix mismatched braces and improve error handling.
- Guard `output$n_animali` against missing data using `req()` before counting rows.

## Testing
- `Rscript -e "parse(file='R/app_server.R')"`

------
https://chatgpt.com/codex/tasks/task_e_68ba072ad538832e854e38ad8d996ae2