### PR TITLE
Expose standardized movimentazioni data and group

### DIFF
--- a/R/mod_file_check.R
+++ b/R/mod_file_check.R
@@ -1,17 +1,15 @@
 # Modulo per controllare le colonne del file caricato                  # descrizione del modulo
 
 mod_file_check_server <- function(id, animali, gruppo) {               # definizione del server del modulo
-	moduleServer(id, function(input, output, session) {            # modulo server vero e proprio
-		
-		reactive({                                             # valore reattivo restituito
-			req(animali())                                 # richiede che i dati siano presenti
-			req(gruppo())                                  # richiede che il gruppo sia definito
-			
-			# verifica che le colonne del dataframe corrispondano a quelle standard per il gruppo
-						identical(colnames(animali()), 
-								col_standard_gruppi[[gruppo()]]
-								) &&        # verifica corrispondenza colonne
-				nrow(animali()) > 0                    # e presenza di almeno una riga
-		})
-	})
+        moduleServer(id, function(input, output, session) {            # modulo server vero e proprio
+
+                reactive({                                             # valore reattivo restituito
+                        req(animali())                                 # richiede che i dati siano presenti
+                        req(gruppo())                                  # richiede che il gruppo sia definito
+
+                        # verifica che le colonne del dataframe corrispondano a quelle standard
+                        identical(colnames(animali()), col_standard) &&       # verifica corrispondenza colonne
+                                nrow(animali()) > 0                    # e presenza di almeno una riga
+                })
+        })
 }

--- a/R/utils-det_gruppo_specie_file.R
+++ b/R/utils-det_gruppo_specie_file.R
@@ -1,13 +1,28 @@
 # script per determinare il tipo di file (differenti tipi per differenti specie)
 
 determinare_gruppo <- function(animali, df_specie) {                   # funzione che determina il gruppo specie
+        gruppo_standard <- attr(animali, "gruppo_specie")              # recupera eventuale gruppo già assegnato
+
         # caso in cui il file sia vuoto
         if (nrow(animali) == 0) {                                       # nessuna riga presente
-                "vuoto"                                                 # ritorna la stringa "vuoto"
+                if (!is.null(gruppo_standard)) {                        # se il gruppo è noto dalle colonne
+                        return(gruppo_standard)                         # restituisce il gruppo dedotto dalla struttura
+                }
+                return("vuoto")                                        # altrimenti segnala file vuoto
+        }
+
+        # identifica la colonna specie a seconda che i dati siano stati standardizzati o meno
+        colonna_specie <- NULL
+        if ("dest_specie" %in% colnames(animali)) {
+                colonna_specie <- "dest_specie"
+        } else if ("SPECIE" %in% colnames(animali)) {
+                colonna_specie <- "SPECIE"
         } else {
+                stop("Colonna delle specie non trovata nel file caricato")
+        }
 
         # prendo tutte le specie presenti
-        specie_presenti <- tolower(unique(animali$SPECIE))              # elenco delle specie in minuscolo
+        specie_presenti <- tolower(unique(animali[[colonna_specie]]))   # elenco delle specie in minuscolo
 
         # mappo al gruppo
         gruppi <- df_specie %>%                                         # unisce con tabella delle specie
@@ -16,11 +31,16 @@ determinare_gruppo <- function(animali, df_specie) {                   # funzion
                 unique()                                               # rimuove eventuali duplicati
 
         if (length(gruppi) == 1) {                                     # un solo gruppo trovato
+                if (!is.null(gruppo_standard) && gruppo_standard != gruppi) {
+                        stop("Il gruppo dedotto dai dati non corrisponde al gruppo atteso dalle colonne standard")
+                }
                 return(gruppi)                                          # restituisce il gruppo
         } else if (length(gruppi) == 0) {                              # nessun gruppo trovato
-                stop("Specie non riconosciute")                         # solleva errore
+                if (!is.null(gruppo_standard)) {
+                        return(gruppo_standard)
+                }
+                stop("Specie non riconosciute")                        # solleva errore
         } else {                                                        # più gruppi trovati
                 stop("File contiene specie di gruppi diversi: ", paste(gruppi, collapse = ", ")) # errore con elenco gruppi
         }
-}
 }


### PR DESCRIPTION
## Summary
- update the movimentazioni upload module to return both the standardized dataset and detected species group
- adapt the main server to consume the new outputs, manage tab state via row counts, and improve status messages
- tidy the file-check helper after the interface change

## Testing
- `R -q -e "cat('ok\n')"` *(fails: command not found: R)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691362f0b744832ebe17d5fa4b2da744)